### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,13 +12,13 @@ WPMControl	KEYWORD3
 # Methods and Functions (KEYWORD2)
 #######################################
 
-WPMControl  KEYWORD2
+WPMControl	KEYWORD2
 connect	KEYWORD2
 disconnect	KEYWORD2
-setMotorSpeed   KEYWORD2
-stopMotor   KEYWORD2
-getSpeed    KEYWORD2
-getState    KEYWORD2
+setMotorSpeed	KEYWORD2
+stopMotor	KEYWORD2
+getSpeed	KEYWORD2
+getState	KEYWORD2
 
 ######################################
 # Instances (KEYWORD2)
@@ -28,6 +28,6 @@ getState    KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-DIR_CW LITERAL1
-DIR_CCW LITERAL1
+DIR_CW	LITERAL1
+DIR_CCW	LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords